### PR TITLE
Make stuffs as singleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+releases/
 node_modules/
 .yarn
 *.cjs

--- a/packages/scan/app/api.ts
+++ b/packages/scan/app/api.ts
@@ -1,0 +1,12 @@
+import { options } from '@parallel-finance/api'
+import { ApiPromise, WsProvider } from '@polkadot/api'
+
+export let api: ApiPromise
+
+export namespace Api {
+  export async function init(endpoint: string) {
+    api = await ApiPromise.create(
+      options({ provider: new WsProvider(endpoint) })
+    )
+  }
+}

--- a/packages/scan/app/model/index.ts
+++ b/packages/scan/app/model/index.ts
@@ -1,10 +1,10 @@
 import { BlockInfo } from './blockInfo'
-import { InternalState } from './internal'
+import { Staker } from './staker'
 
-export type CollectionKey = 'internalState' | 'blockInfo'
+export type CollectionKey = 'blockInfo' | 'staker'
 
-export type CollectionOf<T extends CollectionKey> = T extends 'internalState'
-  ? InternalState
-  : T extends 'blockInfo'
+export type CollectionOf<T> = T extends 'blockInfo'
   ? BlockInfo
+  : T extends 'staker'
+  ? Staker
   : never

--- a/packages/scan/app/model/staker.ts
+++ b/packages/scan/app/model/staker.ts
@@ -1,0 +1,5 @@
+import { CollectionCommon } from './common'
+
+export interface Staker extends CollectionCommon {
+  total: number
+}

--- a/packages/scan/app/scanner/events/index.ts
+++ b/packages/scan/app/scanner/events/index.ts
@@ -1,0 +1,4 @@
+import liquidStaking from './liquidStaking'
+export default {
+  liquidStaking: liquidStaking,
+}

--- a/packages/scan/app/scanner/events/liquidStaking/index.ts
+++ b/packages/scan/app/scanner/events/liquidStaking/index.ts
@@ -1,8 +1,9 @@
-import { Operator } from '../../../types'
 import { Event } from '@polkadot/types/interfaces'
+import { logger } from '../../../logger'
 
 export default {
-  staked: async (event: Event, operator: Operator) => {
+  staked: async (event: Event) => {
     const [who, amount] = event.data
+    logger.debug(`Receive [Staked(${who}, ${amount})] event`)
   },
 }

--- a/packages/scan/app/scanner/events/liquidStaking/index.ts
+++ b/packages/scan/app/scanner/events/liquidStaking/index.ts
@@ -1,0 +1,8 @@
+import { Operator } from '../../../types'
+import { Event } from '@polkadot/types/interfaces'
+
+export default {
+  staked: async (event: Event, operator: Operator) => {
+    const [who, amount] = event.data
+  },
+}

--- a/packages/scan/app/scanner/index.ts
+++ b/packages/scan/app/scanner/index.ts
@@ -1,29 +1,28 @@
-import { ApiPromise } from '@polkadot/api'
 import { BlockHash, Event } from '@polkadot/types/interfaces'
-import { Task, Operator, EventHandler } from '../types'
 import eventHandlers from './events'
+import { EventHandler } from '../types'
+import { api } from '../api'
 
-export class Scanner {
-  private api: ApiPromise
+class Scanner {
   private handlers: { [section: string]: { [method: string]: EventHandler } }
-  constructor(api: ApiPromise) {
-    this.api = api
+
+  constructor() {
     this.handlers = eventHandlers
   }
 
-  async handleEvent(event: Event, operator: Operator) {
+  async handleEvent(event: Event) {
     const { section, method } = event
     if (!this.handlers[section] || !this.handlers[section][method]) {
       return
     }
     const handler = this.handlers[section][method]
-    await handler(event, operator)
+    await handler(event)
   }
 
-  async processBlock(hash: BlockHash, operator: Operator) {
-    const events = await this.api.query.system.events.at(hash)
-    await Promise.all(
-      events.map(({ event }) => this.handleEvent(event, operator))
-    )
+  async processBlock(hash: BlockHash) {
+    const events = await api.query.system.events.at(hash)
+    await Promise.all(events.map(({ event }) => this.handleEvent(event)))
   }
 }
+
+export const scanner = new Scanner()

--- a/packages/scan/app/scanner/index.ts
+++ b/packages/scan/app/scanner/index.ts
@@ -1,11 +1,9 @@
 import { ApiPromise } from '@polkadot/api'
 import { BlockHash, EventRecord } from '@polkadot/types/interfaces'
 import { CollectionKey, CollectionOf } from '../model'
+import { Task } from '../task'
 
-type Operator<T extends CollectionKey> = (
-  key: T,
-  record: CollectionOf<T>
-) => Promise<void>
+type Operator = (task: Task) => Promise<void>
 
 export class Scanner {
   private api: ApiPromise
@@ -13,17 +11,11 @@ export class Scanner {
     this.api = api
   }
 
-  async handleEvent<T extends CollectionKey>(
-    event: EventRecord,
-    operator: Operator<T>
-  ) {
+  async handleEvent(event: EventRecord, operator: Operator) {
     return
   }
 
-  async processBlock<T extends CollectionKey>(
-    hash: BlockHash,
-    operator: Operator<T>
-  ) {
+  async processBlock(hash: BlockHash, operator: Operator) {
     const events = await this.api.query.system.events.at(hash)
     await Promise.all(events.map((e) => this.handleEvent(e, operator)))
   }

--- a/packages/scan/app/scanner/index.ts
+++ b/packages/scan/app/scanner/index.ts
@@ -1,22 +1,29 @@
 import { ApiPromise } from '@polkadot/api'
-import { BlockHash, EventRecord } from '@polkadot/types/interfaces'
-import { CollectionKey, CollectionOf } from '../model'
-import { Task } from '../task'
-
-type Operator = (task: Task) => Promise<void>
+import { BlockHash, Event } from '@polkadot/types/interfaces'
+import { Task, Operator, EventHandler } from '../types'
+import eventHandlers from './events'
 
 export class Scanner {
   private api: ApiPromise
+  private handlers: { [section: string]: { [method: string]: EventHandler } }
   constructor(api: ApiPromise) {
     this.api = api
+    this.handlers = eventHandlers
   }
 
-  async handleEvent(event: EventRecord, operator: Operator) {
-    return
+  async handleEvent(event: Event, operator: Operator) {
+    const { section, method } = event
+    if (!this.handlers[section] || !this.handlers[section][method]) {
+      return
+    }
+    const handler = this.handlers[section][method]
+    await handler(event, operator)
   }
 
   async processBlock(hash: BlockHash, operator: Operator) {
     const events = await this.api.query.system.events.at(hash)
-    await Promise.all(events.map((e) => this.handleEvent(e, operator)))
+    await Promise.all(
+      events.map(({ event }) => this.handleEvent(event, operator))
+    )
   }
 }

--- a/packages/scan/app/service.ts
+++ b/packages/scan/app/service.ts
@@ -44,10 +44,7 @@ export class Service {
         continue
       }
       await this.scanner.processBlock(hash, this.db.insertRecord.bind(this.db))
-      await this.db.insertRecord('blockInfo', {
-        blockHeight: blockNumber,
-        hash: hash.toString(),
-      })
+      await this.db.setLastBlock(blockNumber, hash.toHex())
       logger.debug(`Block#${blockNumber} indexed`)
     }
   }
@@ -65,10 +62,7 @@ export class Service {
 
     const genesisHash = await this.api.rpc.chain.getBlockHash(0)
     logger.debug(`Init genesis blcok: ${genesisHash.toHex()}`)
-    await this.db.insertRecord('blockInfo', {
-      blockHeight: 0,
-      hash: genesisHash.toHex(),
-    })
+    await this.db.setLastBlock(0, genesisHash.toHex())
   }
 
   private async upcomingBlock(): Promise<[number, BlockHash]> {

--- a/packages/scan/app/service.ts
+++ b/packages/scan/app/service.ts
@@ -1,10 +1,9 @@
-import { options } from '@parallel-finance/api'
-import { ApiPromise, WsProvider } from '@polkadot/api'
 import { BlockHash } from '@polkadot/types/interfaces'
-import { Scanner } from './scanner'
-import { Store } from './store'
+import { scanner } from './scanner'
+import { Store, store } from './store'
 import { sleep } from './utils'
 import { logger } from './logger'
+import { Api, api } from './api'
 
 interface ServiceOption {
   endpoint: string
@@ -12,26 +11,12 @@ interface ServiceOption {
 }
 
 export class Service {
-  private scanner: Scanner
-  private db: Store
-  private api: ApiPromise
-
-  constructor(scanner: Scanner, db: Store, api: ApiPromise) {
-    this.scanner = scanner
-    this.db = db
-    this.api = api
-  }
-
   static async build({ endpoint, url }: ServiceOption) {
-    const api = await ApiPromise.create(
-      options({
-        provider: new WsProvider(endpoint),
-      })
-    )
-    const db = await Store.create(url)
-    const scanner = new Scanner(api)
-    return new Service(scanner, db, api)
+    await Api.init(endpoint)
+    await Store.init(url)
+    return new Service()
   }
+
   async run() {
     await this.restore()
     while (true) {
@@ -43,34 +28,34 @@ export class Service {
         await this.revertToFinalized()
         continue
       }
-      await this.scanner.processBlock(hash, this.db.insertRecord.bind(this.db))
-      await this.db.setLastBlock(blockNumber, hash.toHex())
+      await scanner.processBlock(hash)
+      await store.setLastBlock(blockNumber, hash.toHex())
       logger.debug(`Block#${blockNumber} indexed`)
     }
   }
 
   private async restore() {
     // This block is ok cause it's committed at the last of workflow.
-    const lastBlock = await this.db.lastBlockInfo()
+    const lastBlock = await store.lastBlockInfo()
     if (lastBlock) {
       logger.debug(
         `Drop block till #${lastBlock.blockHeight}:${lastBlock.hash}`
       )
-      await this.db.resetTo(lastBlock.blockHeight)
+      await store.resetTo(lastBlock.blockHeight)
       return
     }
 
-    const genesisHash = await this.api.rpc.chain.getBlockHash(0)
+    const genesisHash = await api.rpc.chain.getBlockHash(0)
     logger.debug(`Init genesis blcok: ${genesisHash.toHex()}`)
-    await this.db.setLastBlock(0, genesisHash.toHex())
+    await store.setLastBlock(0, genesisHash.toHex())
   }
 
   private async upcomingBlock(): Promise<[number, BlockHash]> {
-    const { blockHeight } = await this.db.lastBlockInfo()
+    const { blockHeight } = await store.lastBlockInfo()
     const currentBlockNumber = blockHeight + 1
     while (true) {
       try {
-        const hash = await this.api.rpc.chain.getBlockHash(currentBlockNumber)
+        const hash = await api.rpc.chain.getBlockHash(currentBlockNumber)
         return [currentBlockNumber, hash]
       } catch {
         // It means the last block is the newest
@@ -81,17 +66,17 @@ export class Service {
   }
 
   private async isForkedBlock(hash: BlockHash) {
-    const { hash: lastHash } = await this.db.lastBlockInfo()
-    const { parentHash } = await this.api.rpc.chain.getHeader(hash)
+    const { hash: lastHash } = await store.lastBlockInfo()
+    const { parentHash } = await api.rpc.chain.getHeader(hash)
     return parentHash.toHex() !== lastHash
   }
 
   private async revertToFinalized() {
-    const finalizedHash = await this.api.rpc.chain.getFinalizedHead()
+    const finalizedHash = await api.rpc.chain.getFinalizedHead()
     const finalizedHeight = (
-      await this.api.rpc.chain.getHeader(finalizedHash)
+      await api.rpc.chain.getHeader(finalizedHash)
     ).number.toNumber()
     logger.debug(`Reset database to Block#${finalizedHeight}`)
-    await this.db.resetTo(finalizedHeight)
+    await store.resetTo(finalizedHeight)
   }
 }

--- a/packages/scan/app/store/index.ts
+++ b/packages/scan/app/store/index.ts
@@ -1,4 +1,3 @@
-import { Task } from '../types'
 import { Db, MongoClient } from 'mongodb'
 import { CollectionKey, CollectionOf } from '../model'
 import { BlockInfo } from '../model/blockInfo'
@@ -12,10 +11,10 @@ export class Store {
     this.client = client
   }
 
-  static async create(url: string) {
+  static async init(url: string) {
     const client = new MongoClient(url)
     await client.connect()
-    return new Store(client)
+    store = new Store(client)
   }
 
   getCols<T extends CollectionKey>(key: T) {
@@ -23,13 +22,7 @@ export class Store {
   }
 
   async setLastBlock(height: number, hash: string) {
-    this.insertRecord({
-      col: 'blockInfo',
-      record: {
-        blockHeight: height,
-        hash,
-      },
-    })
+    await this.getCols('blockInfo').insertOne({ blockHeight: height, hash })
   }
 
   /**
@@ -56,8 +49,6 @@ export class Store {
       })
     }
   }
-
-  async insertRecord(task: Task) {
-    await this.getCols(task.col).insertOne(task.record)
-  }
 }
+
+export let store: Store

--- a/packages/scan/app/store/index.ts
+++ b/packages/scan/app/store/index.ts
@@ -1,4 +1,4 @@
-import { Task } from 'app/task'
+import { Task } from '../types'
 import { Db, MongoClient } from 'mongodb'
 import { CollectionKey, CollectionOf } from '../model'
 import { BlockInfo } from '../model/blockInfo'

--- a/packages/scan/app/store/index.ts
+++ b/packages/scan/app/store/index.ts
@@ -1,3 +1,4 @@
+import { Task } from 'app/task'
 import { Db, MongoClient } from 'mongodb'
 import { CollectionKey, CollectionOf } from '../model'
 import { BlockInfo } from '../model/blockInfo'
@@ -19,6 +20,16 @@ export class Store {
 
   getCols<T extends CollectionKey>(key: T) {
     return this.db.collection<CollectionOf<T>>(key)
+  }
+
+  async setLastBlock(height: number, hash: string) {
+    this.insertRecord({
+      col: 'blockInfo',
+      record: {
+        blockHeight: height,
+        hash,
+      },
+    })
   }
 
   /**
@@ -46,7 +57,7 @@ export class Store {
     }
   }
 
-  async insertRecord<T extends CollectionKey>(key: T, record: CollectionOf<T>) {
-    await this.getCols(key).insertOne(record as any)
+  async insertRecord(task: Task) {
+    await this.getCols(task.col).insertOne(task.record)
   }
 }

--- a/packages/scan/app/task.ts
+++ b/packages/scan/app/task.ts
@@ -1,0 +1,10 @@
+import { CollectionKey, CollectionOf } from './model'
+
+type Distribute<U> = U extends any
+  ? {
+      col: U
+      record: CollectionOf<U>
+    }
+  : never
+
+export type Task = Distribute<CollectionKey>

--- a/packages/scan/app/types.ts
+++ b/packages/scan/app/types.ts
@@ -1,13 +1,4 @@
 import { CollectionKey, CollectionOf } from './model'
 import { Event } from '@polkadot/types/interfaces'
 
-type Distribute<U> = U extends any
-  ? {
-      col: U
-      record: CollectionOf<U>
-    }
-  : never
-
-export type Task = Distribute<CollectionKey>
-export type Operator = (task: Task) => Promise<void>
-export type EventHandler = (event: Event, operator: Operator) => Promise<void>
+export type EventHandler = (event: Event) => Promise<void>

--- a/packages/scan/app/types.ts
+++ b/packages/scan/app/types.ts
@@ -1,4 +1,5 @@
 import { CollectionKey, CollectionOf } from './model'
+import { Event } from '@polkadot/types/interfaces'
 
 type Distribute<U> = U extends any
   ? {
@@ -8,3 +9,5 @@ type Distribute<U> = U extends any
   : never
 
 export type Task = Distribute<CollectionKey>
+export type Operator = (task: Task) => Promise<void>
+export type EventHandler = (event: Event, operator: Operator) => Promise<void>

--- a/packages/scan/index.ts
+++ b/packages/scan/index.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander'
-import { Service } from 'app/service'
+import { Service } from './app/service'
 
 interface Options {
   endpoint: string
@@ -12,14 +12,14 @@ program
   .option(
     '--endpoint <string>',
     'Parallel endpoint',
-    'wss://testnet.parallel.fi'
+    'wss://test-para-rpc.parallel.fi'
   )
-  .option('--url <string>', 'The mongodb url')
+  .option('--url <string>', 'The mongodb url', 'mongodb://localhost:27017')
 
 async function main() {
   program.parse()
   let options = program.opts<Options>()
-  let service = await Service.build(options)
+  const service = await Service.build(options)
   await service.run()
 }
 

--- a/packages/scan/tsconfig.json
+++ b/packages/scan/tsconfig.json
@@ -9,6 +9,7 @@
     "removeComments": true,
     "noImplicitAny": false,
     "esModuleInterop": true,
+    "target": "ESNext",
     "preserveConstEnums": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
It's better to make scanner/store as singletons, since in some situations the scanner also needs extra information from database